### PR TITLE
Update OPT-IN Framework Standard to v1.2

### DIFF
--- a/OPT-IN_FRAMEWORK/README.md
+++ b/OPT-IN_FRAMEWORK/README.md
@@ -1,7 +1,7 @@
 # OPT-IN Framework
 
-**Version:** 1.1  
-**Date:** 2025-11-13  
+**Version:** 1.2
+**Date:** 2025-11-17
 **Status:** Active
 
 ## Overview
@@ -200,11 +200,11 @@ For complete specification, see:
 
 ## Document Control
 
-- **Version**: 1.1
+- **Version**: 1.2
 - **Status**: Active
 - **Owner**: AMPEL360 Documentation WG
-- **Standard**: OPT-IN Framework v1.1
-- **Last Updated**: 2025-11-13
+- **Standard**: OPT-IN Framework v1.2
+- **Last Updated**: 2025-11-17
 
 ---
 

--- a/OPT-IN_FRAMEWORK_STANDARD.md
+++ b/OPT-IN_FRAMEWORK_STANDARD.md
@@ -1,8 +1,8 @@
 # OPT-IN Framework — Top-Level Standard & Cross-ATA Bucket Schema
 
-**Version:** 1.1  
-**Date:** 2025-11-13  
-**Status:** Active  
+**Version:** 1.2
+**Date:** 2025-11-17
+**Status:** Active
 **Owner:** AMPEL360 Documentation WG
 
 ---
@@ -291,7 +291,62 @@ ATA_XX-DESCRIPTION/
 
 ---
 
-## 5. Rules (Concise)
+## 5. Definitions (One-Liners)
+
+- **00 General** — General ATA information, audience-based instructions, regulations, governance, standards, configuration & change management.
+- **10 Operations** — Operational use, turnaround, ground/flight ops specifics for the ATA domain.
+- **20 Subsystems** — Functional systems of the domain; main engineering artefacts live here.
+- **30 Circularity** — Sustainability, repairability, reuse/recycle, LCA, carbon accounting.
+- **40 Software** — Embedded apps, controllers, diagnostics, analytics, ML/NN for the domain.
+- **50 Structures** — Frames, housings, supports, structural routes.
+- **60 Storages** — Tanks, reservoirs, accumulators, cryogenic storages (H₂, oils, etc.).
+- **70 Propulsion** — Propulsive interface items/couplings (when applicable).
+- **80 Energy** — Electrical/thermal energy conversion, distribution, interfaces.
+- **90 Schemas** — Data schemas, tables, catalogs, drawing indexes, SDS, training.
+
+---
+
+## 6. Example — ATA 79 (OIL)
+
+```
+ATA_79-OIL/
+├── 79-00_GENERAL/                    # 14 lifecycle folders (mandatory)
+│   ├── 79-00-01_Overview/
+│   ├── 79-00-02_Safety/
+│   ├── 79-00-03_Requirements/
+│   ├── 79-00-04_Design/
+│   ├── 79-00-05_Interfaces/
+│   ├── 79-00-06_Engineering/
+│   ├── 79-00-07_V_AND_V/
+│   ├── 79-00-08_Prototyping/
+│   ├── 79-00-09_Production_Planning/
+│   ├── 79-00-10_Certification/
+│   ├── 79-00-11_EIS_Versions_Tags/
+│   ├── 79-00-12_Services/
+│   ├── 79-00-13_Subsystems_Components/
+│   └── 79-00-14_Ops_Std_Sustain/
+├── 79-10_Operations/
+│   └── 79-10-01_Service_Turnaround_Lubes/
+├── 79-20_Subsystems/
+│   ├── 79-20-01_Engine_Oil_System/
+│   └── 79-20-02_Oil_Condition_Monitoring/
+├── 79-30_Circularity/
+│   └── 79-30-01_Waste_Oil_Recovery_LCA/
+├── 79-40_Software/
+│   └── 79-40-01_Oil_Controller_SW/
+├── 79-50_Structures/
+│   └── 79-50-01_Oil_Tank_Mounts/
+├── 79-60_Storages/
+│   └── 79-60-01_Oil_Tank_Aft/
+├── 79-70_Propulsion/                 # if applicable
+├── 79-80_Energy/                     # if applicable
+└── 79-90_Tables_Schemas_Diagrams/
+    └── 79-90-01_Fluid_Specs_Tables/
+```
+
+---
+
+## 7. Rules (Concise)
 
 1. **All chapters include XX-00_GENERAL with all 14 lifecycle folders.**
 2. **Buckets 10/20/30/40/50/60/70/80/90 are present in every chapter.**
@@ -306,7 +361,7 @@ ATA_XX-DESCRIPTION/
 
 ---
 
-## 6. CI Validation
+## 8. CI Validation
 
 The repository includes automated validation to enforce this structure:
 
@@ -320,7 +375,7 @@ The repository includes automated validation to enforce this structure:
 
 ---
 
-## 7. Summary
+## 9. Summary
 
 The OPT-IN Framework provides:
 
@@ -332,10 +387,11 @@ The OPT-IN Framework provides:
 
 ---
 
-## 8. Document Control
+## 10. Document Control
 
 | Version | Date       | Author                      | Changes                                               |
 |---------|------------|-----------------------------|-------------------------------------------------------|
+| 1.2     | 2025-11-17 | AMPEL360 Documentation WG   | Added concise definitions & ATA 79 example            |
 | 1.1     | 2025-11-13 | AMPEL360 Documentation WG   | Initial definition of OPT-IN Framework standard       |
 | 1.0     | 2025-11-12 | AMPEL360 Documentation WG   | Draft specification                                   |
 

--- a/OPTIN_FRAMEWORK_STRUCTURE.md
+++ b/OPTIN_FRAMEWORK_STRUCTURE.md
@@ -1,5 +1,16 @@
 # OPT-IN Framework Structure
 
+> **⚠️ DEPRECATION NOTICE**
+> This document is deprecated as of 2025-11-17.
+> Please refer to [OPT-IN_FRAMEWORK_STANDARD.md](./OPT-IN_FRAMEWORK_STANDARD.md) for the current official specification.
+>
+> **Key differences:**
+> - Updated lifecycle folder naming: `XX-00-01_Overview` (not `01_OVERVIEW`)
+> - Cross-ATA bucket naming: `XX-10_Operations` (not just `10_Operations`)
+> - Current version: 1.2 (2025-11-17)
+
+---
+
 ## Overview
 This directory contains the complete OPT-IN Framework skeleton for the AMPEL360 Blended-Wing-Body (BWB) hydrogen-hybrid aircraft program. The framework provides a structured, certifiable approach to concurrent development and documentation of complex aerospace systems.
 


### PR DESCRIPTION
Enhanced the OPT-IN Framework Standard with:
- Added Section 5: Concise one-liner definitions for all buckets (00, 10-90)
- Added Section 6: Complete ATA 79 (OIL) example demonstrating structure
- Updated section numbering (Rules→7, CI Validation→8, Summary→9, Document Control→10)
- Bumped version to 1.2 (2025-11-17)

Additional changes:
- Deprecated OPTIN_FRAMEWORK_STRUCTURE.md with redirect notice
- Updated OPT-IN_FRAMEWORK/README.md version to 1.2
- All 80 ATA chapters validated successfully against schema

This implements the complete OPT-IN Framework schema specification with:
- 5 top-level axes (O, P, T, I, N)
- 15 Technology sub-branches (A, M, E1-E3, D, O, P, L1-L2, I, C1-C2, I2, A2)
- 14 mandatory lifecycle folders in XX-00_GENERAL
- 9 mandatory cross-ATA buckets (10/20/30/40/50/60/70/80/90)

## Summary by Sourcery

Update the OPT-IN Framework Standard to v1.2 by introducing concise bucket definitions, providing an ATA 79 example, renumbering sections, deprecating the old structure document, updating version metadata, and validating all ATA chapters

New Features:
- Add one-liner bucket definitions in Section 5
- Include a complete ATA 79 (OIL) structure example in Section 6
- Deprecate OPTIN_FRAMEWORK_STRUCTURE.md with a redirect to the new standard

Enhancements:
- Renumber Rules, CI Validation, Summary, and Document Control sections
- Bump version to 1.2 and update dates in main standard and README
- Validate all 80 ATA chapters against the OPT-IN schema