### PR TITLE
Add canonical A-LIVE-GP definition across framework standards

### DIFF
--- a/AMPEL360_DOCUMENTATION_STANDARD.md
+++ b/AMPEL360_DOCUMENTATION_STANDARD.md
@@ -230,6 +230,61 @@ ATA_XX-SYSTEM_NAME/
   * How it applies to this ATA chapter
   * Status (`Pending`, `Draft`, `Active`, `Deprecated`)
 
+#### A-LIVE-GP – 14-Folder Lifecycle Skeleton
+
+The standard 14-folder structure used in all `XX-00-00_GENERAL` layers implements the:
+
+**A-LIVE-GP — Aircraft Lifecycle Industrialization and Validation Executive General Plan**
+
+A-LIVE-GP is the canonical lifecycle skeleton for every ATA chapter in the OPT-IN Framework.
+It ensures that all systems, subsystems and interfaces are engineered, validated and industrialized under a consistent, certification-grade plan.
+
+##### A-LIVE-GP Folder Mapping
+
+Each `XX-00-00_GENERAL` chapter uses the following 14 folders to implement A-LIVE-GP:
+
+1. **01_OVERVIEW**
+   Program / chapter mission, scope, architecture context, stakeholders and governance.
+
+2. **02_SAFETY**
+   Safety objectives, FHA/PSSA allocation, risks, mitigations and safety governance.
+
+3. **03_REQUIREMENTS**
+   Structured requirements set (functional, performance, safety, regulatory) with IDs and traceability hooks.
+
+4. **04_DESIGN**
+   Logical and physical architecture, models, design decisions, trades and baselines.
+
+5. **05_INTERFACES**
+   Internal and external interfaces, ICDs, data contracts, infra standards (e.g. ATA 85), and change control.
+
+6. **06_ENGINEERING**
+   Detailed engineering work: analyses, simulations, dimensioning, models, calculations, algorithms.
+
+7. **07_V_AND_V**
+   Verification & Validation strategy, plans, procedures, coverage and results mapping to requirements.
+
+8. **08_PROTOTYPING**
+   Breadboards, rigs, mock-ups, PoCs, pilots, and digital/physical prototyping campaigns (ground + flight where applicable).
+
+9. **09_PRODUCTION_PLANNING**
+   Industrialization, supply chain, producibility, process design, production tooling and ramp-up planning.
+
+10. **10_CERTIFICATION**
+    Certification basis, means of compliance, evidence structure (DO-178C, DO-254, DO-160, CS-25, etc.) and authority interactions.
+
+11. **11_EIS_VERSIONS_TAGS**
+    Entry-Into-Service strategy, versioning model, tags, release notes, in-service modifications and configuration records.
+
+12. **12_SERVICES**
+    In-service support: operations support, maintenance program hooks, digital services, customer services integration.
+
+13. **13_SUBSYSTEMS_COMPONENTS**
+    Breakdown of subsystems and components under the chapter, with allocation to responsible teams and cross-ATA links.
+
+14. **14_OPS_STD_SUSTAIN**
+    Operations standards, procedures, performance standards and sustainability/circularity hooks (integration with ATA 02/99).
+
 ### 2.2 Origin Blocks: 20 / 40 / 50 / 70 / 90
 
 The following “origin blocks” are used consistently:

--- a/OPT-IN_FRAMEWORK/I-INFRASTRUCTURES/ATA_85-INFRASTRUCTURE_INTERFACE_STANDARDS/85-00_GENERAL/85-00-01_Overview/README.md
+++ b/OPT-IN_FRAMEWORK/I-INFRASTRUCTURES/ATA_85-INFRASTRUCTURE_INTERFACE_STANDARDS/85-00_GENERAL/85-00-01_Overview/README.md
@@ -88,9 +88,17 @@ This overview documentation provides traceability to:
 - **Status**: Active
 - **Last Updated**: 2025-11-21
 
+## Lifecycle Skeleton (A-LIVE-GP)
+
+This `85-00_GENERAL` layer follows the **A-LIVE-GP (Aircraft Lifecycle Industrialization and Validation Executive General Plan)** model.
+
+All content is organized into 14 standard folders (01_Overview … 14_OPS_STD_SUSTAIN), which together implement the end-to-end lifecycle: from concept, safety and requirements through design, V&V, prototyping and industrialization, down to certification, EIS, services and long-term sustainment.
+
+For ATA 85 (Infrastructure Interface Standards), A-LIVE-GP ensures that all infrastructure interfaces—H₂ refuelling farms, CO₂ battery docks, GSE access, passenger evacuation flows, emergency services integration, and airport compatibility—are engineered, validated, certified, and industrialized under a consistent, certification-grade plan that integrates seamlessly with airport operators, energy suppliers, and regulatory authorities.
+
 ## Related Folders
 
-Part of the canonical 14-folder lifecycle:
+Part of the canonical 14-folder lifecycle (A-LIVE-GP):
 1. Overview → 2. Safety → 3. Requirements → 4. Design → 5. Interfaces → 6. Engineering → 7. V&V → 8. Prototyping → 9. Production Planning → 10. Certification → 11. EIS/Versions/Tags → 12. Services → 13. Subsystems/Components → 14. Ops/Std/Sustain
 
 ## Document Control

--- a/OPT-IN_FRAMEWORK_STANDARD.md
+++ b/OPT-IN_FRAMEWORK_STANDARD.md
@@ -190,11 +190,66 @@ ATA_XX-DESCRIPTION/
     └── XX-00-14_Ops_Std_Sustain/
 ```
 
-### 3.1 Source Pattern
+### 3.1 A-LIVE-GP – 14-Folder Lifecycle Skeleton
+
+The standard 14-folder structure used in all `XX-00-00_GENERAL` layers implements the:
+
+**A-LIVE-GP — Aircraft Lifecycle Industrialization and Validation Executive General Plan**
+
+A-LIVE-GP is the canonical lifecycle skeleton for every ATA chapter in the OPT-IN Framework.
+It ensures that all systems, subsystems and interfaces are engineered, validated and industrialized under a consistent, certification-grade plan.
+
+#### A-LIVE-GP Folder Mapping
+
+Each `XX-00-00_GENERAL` chapter uses the following 14 folders to implement A-LIVE-GP:
+
+1. **01_OVERVIEW**
+   Program / chapter mission, scope, architecture context, stakeholders and governance.
+
+2. **02_SAFETY**
+   Safety objectives, FHA/PSSA allocation, risks, mitigations and safety governance.
+
+3. **03_REQUIREMENTS**
+   Structured requirements set (functional, performance, safety, regulatory) with IDs and traceability hooks.
+
+4. **04_DESIGN**
+   Logical and physical architecture, models, design decisions, trades and baselines.
+
+5. **05_INTERFACES**
+   Internal and external interfaces, ICDs, data contracts, infra standards (e.g. ATA 85), and change control.
+
+6. **06_ENGINEERING**
+   Detailed engineering work: analyses, simulations, dimensioning, models, calculations, algorithms.
+
+7. **07_V_AND_V**
+   Verification & Validation strategy, plans, procedures, coverage and results mapping to requirements.
+
+8. **08_PROTOTYPING**
+   Breadboards, rigs, mock-ups, PoCs, pilots, and digital/physical prototyping campaigns (ground + flight where applicable).
+
+9. **09_PRODUCTION_PLANNING**
+   Industrialization, supply chain, producibility, process design, production tooling and ramp-up planning.
+
+10. **10_CERTIFICATION**
+    Certification basis, means of compliance, evidence structure (DO-178C, DO-254, DO-160, CS-25, etc.) and authority interactions.
+
+11. **11_EIS_VERSIONS_TAGS**
+    Entry-Into-Service strategy, versioning model, tags, release notes, in-service modifications and configuration records.
+
+12. **12_SERVICES**
+    In-service support: operations support, maintenance program hooks, digital services, customer services integration.
+
+13. **13_SUBSYSTEMS_COMPONENTS**
+    Breakdown of subsystems and components under the chapter, with allocation to responsible teams and cross-ATA links.
+
+14. **14_OPS_STD_SUSTAIN**
+    Operations standards, procedures, performance standards and sustainability/circularity hooks (integration with ATA 02/99).
+
+### 3.2 Source Pattern
 - **Source**: ATA 95-00-00_GENERAL (canonical template)
 - **Purpose**: This folder owns governance, requirements, safety, certification, config/change management for the chapter
 
-### 3.2 Lifecycle Folder Descriptions
+### 3.3 Lifecycle Folder Descriptions
 
 1. **XX-00-01_Overview**: ATA domain description and global architecture
 2. **XX-00-02_Safety**: Safety framework and analysis methods


### PR DESCRIPTION
Make A-LIVE-GP (Aircraft Lifecycle Industrialization and Validation Executive General Plan) canonical and reusable across all ATA XX-00-00_GENERAL folders.

Changes:
- OPT-IN_FRAMEWORK_STANDARD.md: Add comprehensive A-LIVE-GP definition and 14-folder mapping in section 3.1
- AMPEL360_DOCUMENTATION_STANDARD.md: Add A-LIVE-GP definition to section 2.1 GENERAL Layer
- ATA 85-00-01_Overview/README.md: Add ATA-85-specific A-LIVE-GP context explaining how lifecycle applies to infrastructure interfaces

A-LIVE-GP establishes the canonical lifecycle skeleton ensuring all systems, subsystems and interfaces are engineered, validated and industrialized under a consistent, certification-grade plan.

## Summary by Sourcery

Add and centralize the canonical A-LIVE-GP lifecycle definition and 14-folder structure across framework and ATA documentation to ensure consistent engineering, validation, and industrialization processes.

Documentation:
- Introduce A-LIVE-GP definition and 14-folder lifecycle mapping in the OPT-IN Framework Standard (section 3.1).
- Add A-LIVE-GP lifecycle skeleton and folder mapping to the AMPEL360 Documentation Standard’s GENERAL layer.
- Enhance the ATA 85-00-01 Overview to reference the A-LIVE-GP model and align infrastructure interface standards under the lifecycle plan.